### PR TITLE
Creio que os proxies deveriam ser unicos.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,14 +3,17 @@
 .settings/*
 reconf-client/.settings/*
 reconf-client/target/*
+reconf-client/bin/*
 reconf-client/.classpath
 reconf-client/.project
 reconf-infra/.settings/*
 reconf-infra/target/*
+reconf-infra/bin/*
 reconf-infra/.classpath
 reconf-infra/.project
 reconf-spring/.settings/*
 reconf-spring/target/*
+reconf-spring/bin/*
 reconf-spring/.classpath
 reconf-spring/.project
 reconf-spring/.springBeans


### PR DESCRIPTION
Encontrei um problema nos clients. Se temos mais de um proxy de uma mesma interface todo o processo (schedule, conexoes http com o servidor etc) é replicado podendo gerar requisições desnecessárias ao servidor. Criando caches de proxies podemos evitar isso de uma maneira transparente, dado que os proxies sejam thread-safe (e eles sao).
